### PR TITLE
_handler_relay.rb

### DIFF
--- a/recipes/_handler_relay.rb
+++ b/recipes/_handler_relay.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'monitor::_extensions'
-include_recipe 'monitor::_graphite_search'
+include_recipe 'monitor::_search_graphite'
 
 if node['sensu'].key?('graphite')
 


### PR DESCRIPTION
wrong include
include_recipe 'monitor::_graphite_search'
new include:
include_recipe 'monitor::_search_graphite'
