### PR TITLE
Fix failing chef client run  on windows

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -68,6 +68,8 @@ suites:
       use_statsd_input: true
     # rabbitmq:
     #   use_distro_version: true
+  excludes:
+    - windows-2012r2
 - name: server-redis
   run_list:
     - recipe[monitor::master]
@@ -87,6 +89,8 @@ suites:
       redis_db: 1
     # rabbitmq:
     #   use_distro_version: true
+  excludes:
+    - windows-2012r2
 - name: client
   run_list:
     - recipe[monitor::client]
@@ -102,6 +106,25 @@ suites:
       use_nagios_plugins: false
       use_system_profile: true
       use_statsd_input: true
+  excludes:
+    - windows-2012r2
+- name: windows-client
+  run_list:
+    - recipe[monitor::client]
+  attributes:
+    apt:
+     compile_time_update: true
+    authorization:
+      sudo:
+        users: ["vagrant", "kitchen"]
+        passwordless: true
+        include_sudoers_d: true
+    monitor:
+      use_nagios_plugins: false
+      use_system_profile: true
+      use_statsd_input: true
+  includes:
+    - windows-2012r2
 - name: client-redis
   run_list:
     - recipe[monitor::client]
@@ -118,3 +141,5 @@ suites:
       use_system_profile: true
       use_statsd_input: true
       transport: redis
+  excludes:
+    - windows-2012r2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -42,6 +42,13 @@ platforms:
     run_list:
       - recipe[yum]
       - recipe[monitor::_kitchen_centos7]
+  - name: windows-2012r2
+    driver:
+      box: mwrock/Windows2012R2
+    communicator: winrm
+    customize:
+      usb: "off"  # USB is disabled on this box to make it more lightweight
+      vrde: "on"  # enable RDP
 
 suites:
 - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,8 +54,14 @@ default['monitor']['metric_interval'] = 60
 default['monitor']['metric_occurrences'] = 2
 default['monitor']['metric_disabled'] = false
 
-default['monitor']['client_extension_dir'] = '/etc/sensu/extensions/client'
-default['monitor']['server_extension_dir'] = '/etc/sensu/extensions/server'
+# platform
+if platform_family?("windows")
+  default['monitor']['client_extension_dir'] = 'C:\etc\sensu\extensions\client'
+  default['monitor']['server_extension_dir'] = 'C:\etc\sensu\extensions\server'
+else
+  default['monitor']['client_extension_dir'] = '/etc/sensu/extensions/client'
+  default['monitor']['server_extension_dir'] = '/etc/sensu/extensions/server'
+end
 
 default['monitor']['snssqs_max_number_of_messages'] = 10
 default['monitor']['snssqs_wait_time_seconds'] = 2

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'phil@hellmi.de'
 license 'Apache-2.0'
 description 'A cookbook for monitoring services, using Sensu, a monitoring framework.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.9.0'
+version '0.9.1'
 chef_version '~> 12'
 
 issues_url 'https://github.com/runningman84/chef-monitor/issues'

--- a/recipes/_check_rabbitmq.rb
+++ b/recipes/_check_rabbitmq.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'build-essential::default'
+include_recipe 'build-essential::default' unless node['os'] == 'windows'
 
 sensu_gem 'sensu-plugins-rabbitmq' do
   version node['monitor']['sensu_gem_versions']['sensu-plugins-rabbitmq']

--- a/recipes/_extensions.rb
+++ b/recipes/_extensions.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+
 %w(
   client
   server
@@ -25,21 +26,23 @@
 
   directory extension_dir do
     recursive true
-    owner 'root'
-    group 'sensu'
+    owner 'root' unless node['os'] == 'windows'
+    group 'sensu' unless node['os'] == 'windows'
     mode 0o750
   end
 
   config_path = case node['platform_family']
-                when 'rhel', 'fedora'
-                  "/etc/sysconfig/sensu-#{service}"
-                else
-                  "/etc/default/sensu-#{service}"
+                  when 'rhel', 'fedora'
+                    "/etc/sysconfig/sensu-#{service}"
+                  when 'windows'
+                    "C:\\etc\\sensu\\conf.d\\sensu-#{service}"
+                  else
+                    "/etc/default/sensu-#{service}"
                 end
 
   file config_path do
-    owner 'root'
-    group 'root'
+    owner 'root' unless node['os'] == 'windows'
+    group 'root' unless node['os'] == 'windows'
     mode 0o744
     content "EXTENSION_DIR=#{extension_dir}"
     notifies :create, 'ruby_block[sensu_service_trigger]', :immediately

--- a/recipes/_handler_chef_node.rb
+++ b/recipes/_handler_chef_node.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'build-essential::default'
+include_recipe 'build-essential::default' unless node['os'] == 'windows'
 
 if File.exist?('/etc/chef/client.rb') && File.exist?('/etc/chef/client.pem')
 

--- a/recipes/_handler_deregistration.rb
+++ b/recipes/_handler_deregistration.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'build-essential::default'
+include_recipe 'build-essential::default' unless node['os'] == 'windows'
 
 include_recipe 'monitor::_filters'
 

--- a/recipes/_handler_ec2_node.rb
+++ b/recipes/_handler_ec2_node.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'build-essential::default'
+include_recipe 'build-essential::default' unless node['os'] == 'windows'
 
 if node.key?('ec2')
 

--- a/recipes/_plugins_sensu.rb
+++ b/recipes/_plugins_sensu.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'build-essential::default'
+include_recipe 'build-essential::default' unless node['os'] == 'windows'
 
 node['monitor']['sensu_plugins'].each do |name, version|
   sensu_gem "sensu-plugins-#{name}" do

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -73,7 +73,7 @@ sensu_handler 'metrics' do
   handlers active_metric_handlers.uniq
 end
 
-include_recipe 'build-essential::default'
+include_recipe 'build-essential::default' unless node['os'] == 'windows'
 sensu_gem 'sensu-plugins-sensu' do
   version node['monitor']['sensu_gem_versions']['sensu-plugins-sensu']
 end

--- a/test/integration/windows-client/inspec/sensu_spec.rb
+++ b/test/integration/windows-client/inspec/sensu_spec.rb
@@ -1,0 +1,47 @@
+describe package('sensu') do
+  it { should be_installed }
+end
+
+describe user('sensu') do
+  it { should exist }
+end
+
+describe file('/etc/sensu') do
+  it { should be_directory }
+
+end
+
+
+
+describe json('/etc/sensu/config.json') do
+    its(['transport','name']) { should eq 'rabbitmq'}
+    its(['rabbitmq',0,'host']) { should eq 'localhost'} # TODO: port should be 5671
+    its(['redis','host']) { should eq 'localhost'} # TODO: port should be 6379
+    its(['api','host']) { should eq 'localhost'} # TODO: port should be 4567
+end
+
+describe file('/etc/sensu/conf.d') do
+  it { should be_directory }
+end
+
+describe file('/etc/sensu/conf.d/checks') do
+  it { should be_directory }
+end
+describe file('/var/log/sensu') do
+  it { should be_directory }
+end
+
+
+describe file('/var/log/sensu/sensu-client.log') do
+  it { should be_file }
+end
+
+describe 'sensu client' do
+  it 'has a running service of sensu-client' do
+    expect(service('sensu-client')).to be_running
+  end
+
+  it 'has a enabled service of sensu-client' do
+    expect(service('sensu-client')).to be_enabled
+  end
+end


### PR DESCRIPTION
build-essential dependency is broken on windows-2012r2 : 

```
 ================================================================================
        Error executing action `run` on resource 'execute[upgrade msys2 core]'
        ================================================================================

        Mixlib::ShellOut::ShellCommandFailed
        ------------------------------------
        Expected process to exit with [0], but received '1'
        ---- Begin output of .\bin\bash.bat -c '/custom-upgrade.sh' ----
        STDOUT: :: Synchronizing package databases...
        downloading mingw32.db...
        downloading mingw32.db.sig...
        downloading mingw64.db...
        downloading mingw64.db.sig...
        downloading msys.db...
        downloading msys.db.sig...
        downloading msys.db.sig...
        downloading msys.db.sig...
        downloading msys.db.sig...
        downloading msys.db.sig...
        bash 4.3.042-4 -> 4.4.019-2
        pacman 5.0.0.6348.cc5a8f1-1 -> 5.0.1-5
        msys2-runtime 2.4.1.16860.40c26fc-1 -> 2.10.0-2
        resolving dependencies...
        looking for conflicting packages...
        :: msys2-runtime and catgets are in conflict. Remove catgets? [y/N]
        :: msys2-runtime and catgets are in conflict
        STDERR: error: unresolvable package conflicts detected
        error: failed to prepare transaction (conflicting dependencies)
        ---- End output of .\bin\bash.bat -c '/custom-upgrade.sh' ----
        Ran .\bin\bash.bat -c '/custom-upgrade.sh' returned 1

        Resource Declaration:
        ---------------------
        # In C:/Users/vagrant/AppData/Local/Temp/kitchen/cache/cookbooks/mingw/resources/msys2_package.rb

         41:     execute comment do
         42:       command ".\\bin\\bash.bat -c '#{cmd}'"
         43:       cwd f_root
         44:       live_stream true
         45:       environment('MSYSTEM' => 'MSYS')
         46:     end
         47:   end
```
This PR disable use of build-essential in recipes for windows

It also fixes windows issues  in . _extensions.rb